### PR TITLE
docz + react native fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "ui:android": "yarn workspace @democracy-deutschland/mobile-ui android",
     "ui:release:ios": "yarn workspace @democracy-deutschland/mobile-ui release:ios",
     "ui:release:android": "yarn workspace @democracy-deutschland/mobile-ui release:android",
-    "docz": "docz dev --native",
-    "docz:build": "docz build --native"
+    "docz": "docz dev",
+    "docz:build": "docz build"
   },
   "dependencies": {
     "react-native": "0.61.1"
   },
   "devDependencies": {
-    "docz": "^2.0.0-rc.65"
+    "docz": "^2.0.0-rc.67"
   }
 }

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -37,7 +37,7 @@
     "react-native-safe-area-context": "^0.3.6",
     "react-native-screens": "^2.0.0-alpha.3",
     "react-native-tab-view": "^2.10.0",
-    "styled-components": "^4.4.0"
+    "styled-components": "4.4.0-reactnativewebfix"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/mobile-ui/package.json
+++ b/packages/mobile-ui/package.json
@@ -25,7 +25,7 @@
     "react-native": "0.61.1",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-web": "^0.11.7",
-    "styled-components": "^4.4.0"
+    "styled-components": "4.4.0-reactnativewebfix"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/mobile-ui/src/components/Button/Button.mdx
+++ b/packages/mobile-ui/src/components/Button/Button.mdx
@@ -1,10 +1,11 @@
 ---
 name: Button
-route: /
+route: /button
 ---
 
-import { Playground, Props } from 'docz'
-import Button from './index'
+import { Playground, Props } from 'docz';
+import { Text } from 'react-native';
+import Button from './index';
 
 # Button
 
@@ -14,6 +15,6 @@ import Button from './index'
 
 <Playground>
   <Button onPress={() => {}}>
-      <Text>Hello Button</Text>
-    </Button>
+    <Text>Hello Button</Text>
+  </Button>
 </Playground>

--- a/packages/mobile-ui/src/components/Button/Button.mdx
+++ b/packages/mobile-ui/src/components/Button/Button.mdx
@@ -5,7 +5,7 @@ route: /button
 
 import { Playground, Props } from 'docz';
 import { Text } from 'react-native';
-import Button from './index';
+import Button from './';
 
 # Button
 

--- a/packages/mobile-ui/src/components/Instruction/Header.mdx
+++ b/packages/mobile-ui/src/components/Instruction/Header.mdx
@@ -4,7 +4,7 @@ route: /
 ---
 
 import { Playground, Props } from 'docz';
-import Header from './Header.tsx';
+import Header from './Header';
 import Logo from './assets/icon.logo.png';
 
 # Header

--- a/packages/mobile-ui/src/components/Instruction/Header.mdx
+++ b/packages/mobile-ui/src/components/Instruction/Header.mdx
@@ -4,18 +4,15 @@ route: /
 ---
 
 import { Playground, Props } from 'docz';
-import Header from './Header';
+import Header from './Header.tsx';
+import Logo from './assets/icon.logo.png';
 
-# Button
+# Header
 
-<Props of={Button} />
+<Props of={Header} />
 
 ## Basic usage
 
 <Playground>
-  <Header
-    title="the title"
-    description="the description"
-    image={require('./assets/icon.logo.png')}
-  />
+  <Header title="the title" description="the description" image={Logo} />
 </Playground>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "module": "commonjs",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "plugins": [
+      {
+        "name": "typescript-styled-plugin",
+        "lint": {
+          "validProperties": [
+            "shadow-color",
+            "shadow-opacity",
+            "shadow-offset",
+            "shadow-radius",
+            "padding-horizontal",
+            "padding-vertical",
+            "margin-vertical",
+            "margin-horizontal",
+            "tint-color",
+            "aspect-ratio",
+            "elevation"
+          ]
+        }
+      }
+    ]
+  },
+  "exclude": ["node_modules", "android", "ios", "coverage"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16517,10 +16517,10 @@ style-to-object@0.2.3, style-to-object@^0.2.1, style-to-object@^0.2.3:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.0.tgz#4e381e2dab831d0e6ea431c2840a96323e84e21b"
-  integrity sha512-xQ6vTI/0zNjZ1BBDRxyjvBddrxhQ3DxjeCdaLM1lSn5FDnkTOQgRkmWvcUiTajqc5nJqKVl+7sUioMqktD0+Zw==
+styled-components@4.4.0-reactnativewebfix:
+  version "4.4.0-reactnativewebfix"
+  resolved "https://registry.npmjs.org/styled-components/-/styled-components-4.4.0-reactnativewebfix.tgz#101c4c93e6912c7823e43aaba4451f3bc866b4c1"
+  integrity sha512-Y5WuPGEkw6bXabBc7vqaWOkgHAS/etltRE0VGcIebjKplrkDKdIXv8SvE8dAyfy+LMkcXfvAyiFrJN3wy3OyNg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6127,10 +6127,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-docz-core@2.0.0-rc.65:
-  version "2.0.0-rc.65"
-  resolved "https://registry.yarnpkg.com/docz-core/-/docz-core-2.0.0-rc.65.tgz#3f36f00b2177e8c1757499f5d178f1b94ce58b62"
-  integrity sha512-+3h/EEA3e86zp8+ZAKQDLeYuE2sGAtHeJT1CS6tiRsd9FpiOz5eyqJehBl3HAqjoPyhjSqdy/v+DWA0QE1+y4A==
+docz-core@2.0.0-rc.67:
+  version "2.0.0-rc.67"
+  resolved "https://registry.npmjs.org/docz-core/-/docz-core-2.0.0-rc.67.tgz#34ef23bc8810f80ca4e53b7cccf9addb9edbb83a"
+  integrity sha512-9I3uxAsmmW6lZzFek1TIJAA0bQ2wc7lpj7AlOe8bVc071GUrGlA5vbOOLRMyDtWe6bfxTyiH65rSENOM+u7Bwg==
   dependencies:
     "@sindresorhus/slugify" "^0.9.1"
     chalk "^2.4.2"
@@ -6191,21 +6191,21 @@ docz-utils@2.0.0-rc.64:
     unist-util-is "^3.0.0"
     unist-util-visit "^1.4.1"
 
-docz@2.0.0-rc.65, docz@^2.0.0-rc.65:
-  version "2.0.0-rc.65"
-  resolved "https://registry.yarnpkg.com/docz/-/docz-2.0.0-rc.65.tgz#030f60ce6ac1d816a9cabee4783c912b58449b6e"
-  integrity sha512-qN2NgYiTD7xprGPc6ffqEZZ+tJRb77bSdKvNygNaB2RVQUHWIAdmzwqoJ1gcp6k/NG6dgYFUiQ/QtNBPQwHfzA==
+docz@2.0.0-rc.67, docz@^2.0.0-rc.67:
+  version "2.0.0-rc.67"
+  resolved "https://registry.npmjs.org/docz/-/docz-2.0.0-rc.67.tgz#c041a1df989c6eda4b0832c4720c90c4429371f8"
+  integrity sha512-JFTAHhEb9O/nLrOij5gSmHziivbAsq2lGfxp6IVMvB96qvSOkJ8OG9Jz5jS/Hh/ExuGFYO1UOQLm5QhQhCFHjQ==
   dependencies:
     "@emotion/core" "^10.0.16"
     "@mdx-js/react" "^1.0.27"
     array-sort "^1.0.0"
     capitalize "^2.0.0"
-    docz-core "2.0.0-rc.65"
+    docz-core "2.0.0-rc.67"
     fast-deep-equal "^2.0.1"
     gatsby "^2.13.27"
     gatsby-plugin-eslint "^2.0.5"
     gatsby-plugin-typescript "^2.1.6"
-    gatsby-theme-docz "2.0.0-rc.65"
+    gatsby-theme-docz "2.0.0-rc.67"
     lodash "^4.17.14"
     marksy "^8.0.0"
     match-sorter "^3.1.1"
@@ -8032,10 +8032,10 @@ gatsby-telemetry@^1.1.35:
     stack-utils "1.0.2"
     uuid "3.3.3"
 
-gatsby-theme-docz@2.0.0-rc.65:
-  version "2.0.0-rc.65"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-docz/-/gatsby-theme-docz-2.0.0-rc.65.tgz#fc94954c016b4f5604bc876eff085ae0137baa54"
-  integrity sha512-I/SoUaC2QTvlyuXlLi/WNNUg+cPM7fF1uhc2dEgV+mFE6WJh1WaJ31yIgizIePLxIpNy3gNd2XBH1S3mpox1pA==
+gatsby-theme-docz@2.0.0-rc.67:
+  version "2.0.0-rc.67"
+  resolved "https://registry.npmjs.org/gatsby-theme-docz/-/gatsby-theme-docz-2.0.0-rc.67.tgz#b96669a89259b69944b04037b360b971c569576b"
+  integrity sha512-R6ettItQcYjGf5MFg8qS218vfnDBv9yndjQwtd5rTId26raA4daacXsT5SHxD4XqJPMoDVwrG6Kflp/I/bgbOQ==
   dependencies:
     "@emotion/core" "^10.0.14"
     "@emotion/styled" "^10.0.14"
@@ -8045,8 +8045,8 @@ gatsby-theme-docz@2.0.0-rc.65:
     "@theme-ui/typography" "^0.2.5"
     babel-plugin-export-metadata "2.0.0-rc.64"
     copy-text-to-clipboard "^2.1.0"
-    docz "2.0.0-rc.65"
-    docz-core "2.0.0-rc.65"
+    docz "2.0.0-rc.67"
+    docz-core "2.0.0-rc.67"
     emotion-theming "^10.0.14"
     fs-extra "^8.1.0"
     gatsby "^2.13.27"


### PR DESCRIPTION
There were three problems : 

- styled-components 4.4.0 has an issue with react-native-web. The next SC release will have the fix built in so make sure to update when it's released. For now I added `4.4.0-reactnativewebfix`

- Missing tsconfig in repo root causing docz to fail when parsing the component props.

- docz had an issue where lower case component names (e.g. `index.tsx`) has to be manually included in the projects files by modifying `filterComponents` in `doczrc.js`. Thanks to @esturcke this is no longer an issue so I updated to latest version in the next tag. 

Fixes https://github.com/doczjs/docz/issues/1213 

